### PR TITLE
추가 환경설정(JPA) 및 샘플 소스

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,10 @@ dependencies {
     /**
      * Database dependencies
      */
-    runtimeOnly 'com.h2database:h2' // It would be used until the database setup is done.
-    runtimeOnly 'org.postgresql:postgresql' // The version of the connector will be fixed when the database setup is done.
+    // It would be used until the database setup is done.
+    runtimeOnly 'com.h2database:h2'
+    // The version of the connector will be fixed when the database setup is done.
+    runtimeOnly 'org.postgresql:postgresql'
     /**
      * Test dependencies
      */
@@ -40,10 +42,15 @@ dependencies {
     /**
      * Tools
      */
+    /*Lombok*/
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.18'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.18'
+
+    /*swagger*/
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.5.3'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-data-rest', version: '1.5.3'
+
+    /*devtools*/
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
@@ -51,8 +58,10 @@ ext.profile = (!project.hasProperty('profile') || !profile) ? 'dev' : profile
 
 sourceSets {
     main {
+        java {
+        }
         resources {
-            srcDirs "src/main/resources", "src/main/resources-${profile}"
+            srcDirs += ["src/main/resources-${profile}"]
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,13 @@ dependencies {
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.18'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.18'
 
+    /*query dsl*/
+    implementation group: 'com.querydsl', name: 'querydsl-apt', version: '4.4.0'
+    implementation group: 'com.querydsl', name: 'querydsl-jpa', version: '4.4.0'
+    annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', classifier:'jpa', version: '4.4.0'
+    annotationProcessor group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '1.3.5'
+    annotationProcessor group: 'jakarta.persistence', name: 'jakarta.persistence-api', version: '2.2.3'
+
     /*swagger*/
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.5.3'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-data-rest', version: '1.5.3'

--- a/src/main/java/com/imd/yourvoice/config/QueryDslConfig.java
+++ b/src/main/java/com/imd/yourvoice/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.imd.yourvoice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestController.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestController.java
@@ -1,0 +1,26 @@
+package com.imd.yourvoice.sample;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestService testService;
+
+    @GetMapping("/hello")
+    public TestDTO readHello() {
+        return testService.readHello();
+    }
+
+    @PostMapping("/hello")
+    public TestDTO createHello(@Valid @RequestBody TestDTO testDTO) {
+        return testService.createHello(testDTO);
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestDTO.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestDTO.java
@@ -1,0 +1,22 @@
+package com.imd.yourvoice.sample;
+
+import lombok.*;
+
+import javax.validation.constraints.Size;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TestDTO {
+    private Long id;
+    @Size(min = 1, max = 5)
+    private String name;
+
+    public TestEntity toEntity() {
+        return TestEntity.builder()
+                .id(id)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestEntity.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestEntity.java
@@ -1,0 +1,30 @@
+package com.imd.yourvoice.sample;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@Entity
+@Table(name = "TEST")
+public class TestEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String name;
+
+    public TestDTO toDto() {
+        return TestDTO.builder()
+                .id(id)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestRepository.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestRepository.java
@@ -2,6 +2,6 @@ package com.imd.yourvoice.sample;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TestRepository extends JpaRepository<TestEntity, Long> {
+public interface TestRepository extends JpaRepository<TestEntity, Long>, TestRepositoryCustom {
     TestEntity findByName(String name);
 }

--- a/src/main/java/com/imd/yourvoice/sample/TestRepository.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestRepository.java
@@ -1,0 +1,7 @@
+package com.imd.yourvoice.sample;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestRepository extends JpaRepository<TestEntity, Long> {
+    TestEntity findByName(String name);
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestRepositoryCustom.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.imd.yourvoice.sample;
+
+public interface TestRepositoryCustom {
+    TestDTO queryDslTest(TestEntity testEntity);
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestRepositoryImpl.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.imd.yourvoice.sample;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TestRepositoryImpl implements TestRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public TestDTO queryDslTest(TestEntity testEntity) {
+        TestEntity result = queryFactory.selectFrom(QTestEntity.testEntity)
+                .where(QTestEntity.testEntity.name.eq(testEntity.getName()))
+                .fetchOne();
+
+        return result.toDto();
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestService.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestService.java
@@ -1,0 +1,7 @@
+package com.imd.yourvoice.sample;
+
+public interface TestService {
+    TestDTO readHello();
+
+    TestDTO createHello(TestDTO testDTO);
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestServiceImpl.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestServiceImpl.java
@@ -1,0 +1,25 @@
+package com.imd.yourvoice.sample;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestServiceImpl implements TestService {
+
+    private final TestRepository testRepository;
+
+    @Override
+    public TestDTO readHello() {
+        TestDTO result = testRepository.findByName("hello").toDto();
+        return result == null ?
+                createHello(TestDTO.builder().name("hello").build()) :
+                result;
+    }
+
+    @Override
+    public TestDTO createHello(TestDTO testDTO) {
+        TestEntity result = testRepository.save(testDTO.toEntity());
+        return result.toDto();
+    }
+}

--- a/src/main/java/com/imd/yourvoice/sample/TestServiceImpl.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestServiceImpl.java
@@ -11,10 +11,10 @@ public class TestServiceImpl implements TestService {
 
     @Override
     public TestDTO readHello() {
-        TestDTO result = testRepository.findByName("hello").toDto();
+        TestEntity result = testRepository.findByName("hello");
         return result == null ?
                 createHello(TestDTO.builder().name("hello").build()) :
-                result;
+                result.toDto();
     }
 
     @Override

--- a/src/main/resources-dev/application.properties
+++ b/src/main/resources-dev/application.properties
@@ -1,5 +1,8 @@
 spring.profiles.active=dev
-spring.config.import=classpath:common.properties
+spring.config.import=classpath:common.properties, datasource.properties
 #devtools
 spring.devtools.restart.enabled=false
 spring.devtools.livereload.enabled=true
+#h2
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources-dev/datasource.properties
+++ b/src/main/resources-dev/datasource.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources-prod/application.properties
+++ b/src/main/resources-prod/application.properties
@@ -1,1 +1,2 @@
 spring.profiles.active=prod
+spring.jpa.properties.javax.persistence.schema-generation.scripts.action=validate

--- a/src/test/java/com/imd/yourvoice/sample/TestControllerTest.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestControllerTest.java
@@ -1,0 +1,92 @@
+package com.imd.yourvoice.sample;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest
+@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
+class TestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TestService testService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void readHello() throws Exception {
+        TestDTO expected = TestDTO.builder().id(1L).name("hello").build();
+
+        given(testService.readHello())
+                .willReturn(TestDTO.builder().id(1L).name("hello").build());
+
+        mockMvc.perform(get("/hello"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is(expected.getName())));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createHello(TestDTO input, TestDTO expected) throws Exception {
+        given(testService.createHello(input))
+                .willReturn(expected);
+
+        mockMvc.perform(post("/hello")
+                .content(objectMapper.writeValueAsString(input))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is(expected.getName())));
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> createHello() {
+        return Stream.of(
+                Arguments.arguments(
+                        TestDTO.builder().name("hello").build(),
+                        TestDTO.builder().name("hello").build())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createHello_validFail(TestDTO input) throws Exception {
+        mockMvc.perform(post("/hello")
+                .content(objectMapper.writeValueAsString(input))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> createHello_validFail() {
+        return Stream.of(
+                Arguments.arguments(TestDTO.builder().name("length over 5").build())
+        );
+    }
+}

--- a/src/test/java/com/imd/yourvoice/sample/TestControllerTest_integration.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestControllerTest_integration.java
@@ -1,0 +1,55 @@
+package com.imd.yourvoice.sample;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class TestControllerTest_integration {
+
+    @LocalServerPort
+    private int port;
+
+    private String uri;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @BeforeEach
+    void setUri() {
+        uri = "http://localhost:" + port;
+    }
+
+    @Test
+    void readHello() {
+        assertThat(restTemplate.getForObject(uri + "/hello", TestDTO.class))
+                .isEqualTo(TestDTO.builder().id(1L).name("hello").build());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createHello(TestDTO input, TestDTO expected) {
+        assertThat(this.restTemplate.postForObject(uri + "/hello", input, TestDTO.class).getName())
+                .isEqualTo(expected.getName());
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> createHello() {
+        return Stream.of(
+                Arguments.arguments(
+                        TestDTO.builder().name("hello").build(),
+                        TestDTO.builder().id(1L).name("hello").build())
+        );
+    }
+}

--- a/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
@@ -4,14 +4,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
-@DataJpaTest
+@SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class TestRepositoryTest {
 
@@ -42,5 +42,10 @@ class TestRepositoryTest {
         String name = "test";
         TestEntity result = testRepository.findByName(name);
         assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    void queryDslTest() {
+        System.out.println(testRepository.queryDslTest(TestEntity.builder().name("test").build()));
     }
 }

--- a/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.imd.yourvoice.sample;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class TestRepositoryTest {
+
+    @Autowired
+    private TestRepository testRepository;
+
+    @BeforeEach
+    void setUp() {
+        testRepository.save(TestEntity.builder().name("test").build());
+        testRepository.save(TestEntity.builder().name("test2").build());
+    }
+
+    @Test
+    void size() {
+        assertThat(testRepository.findAll().size())
+                .isEqualTo(2);
+    }
+
+    @Test
+    void getOne() {
+        String name = "test";
+        TestEntity result = testRepository.getOne(1L);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+    @Test
+    void findByName() {
+        String name = "test";
+        TestEntity result = testRepository.findByName(name);
+        assertThat(result.getName()).isEqualTo(name);
+    }
+}

--- a/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestRepositoryTest.java
@@ -31,9 +31,9 @@ class TestRepositoryTest {
     }
 
     @Test
-    void getOne() {
+    void findById() {
         String name = "test";
-        TestEntity result = testRepository.getOne(1L);
+        TestEntity result = testRepository.findById(1L).get();
         assertThat(result.getName()).isEqualTo(name);
     }
 

--- a/src/test/java/com/imd/yourvoice/sample/TestServiceImplTest.java
+++ b/src/test/java/com/imd/yourvoice/sample/TestServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.imd.yourvoice.sample;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
+class TestServiceImplTest {
+
+    @Mock
+    private TestRepository testRepository;
+
+    private TestService testService;
+
+    @BeforeEach
+    void setUp() {
+        testService = new TestServiceImpl(testRepository);
+    }
+
+    @Test
+    void readHello() {
+        when(testRepository.findByName("hello"))
+                .thenReturn(TestDTO.builder().id(1L).name("hello").build().toEntity());
+        assertThat(testService.readHello())
+                .isEqualTo(TestDTO.builder().id(1L).name("hello").build());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createHello(TestDTO testDTO, TestDTO expectedDTO) {
+        when(testRepository.save(any(TestEntity.class)))
+                .thenAnswer(invocation -> {
+                    TestEntity result = invocation.getArgument(0);
+                    return TestEntity.builder().id(1L).name(result.getName()).build();
+                });
+
+        assertThat(testService.createHello(testDTO))
+                .isEqualTo(expectedDTO);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> createHello() {
+        return Stream.of(
+                Arguments.arguments(
+                        TestDTO.builder().name("hello").build(),
+                        TestDTO.builder().id(1L).name("hello").build()
+                )
+        );
+    }
+}


### PR DESCRIPTION
전체적인 샘플 구조 및 테스트 작성했습니다.

아래에는 대략적인 진행상황과 컨셉을 작성하겠습니다.

이외에 필요할 것 같은 항목이나 구조 등이 있다면 의견 부탁드립니다.

**build.gradle**

- 이전에 말씀드렸던, 운영에서 스키마 생성되지 않도록 하는 옵션 추가했습니다.
- 쿼리dsl 사용에 필요한 디펜던시 추가 했습니다.

**QueryDslConfig**

- QueryDsl 전역 환경설정입니다.

**TestController**

- 기본적인 read와 craete를 해주는 restAPI 샘플입니다.
- 테스트는 단위테스트와 통합테스트로 나누어 작성했습니다.

**TestService**

- readHello에서 hello가 없을 시 create해줍니다. 이외에 특이사항은 없습니다.

**TestRepository**

- SpringJPA와 QueryDSL을 함께 사용할 수 있도록 세팅했습니다. SpringJPA를 메인으로 사용하고 동적 쿼리 필요시 QueryDSL 사용 예정입니다.
- QueryDSL 샘플은 굳이 서비스에 넣지 않고 테스트로 끝냈습니다.

**TestEntity**

- DB의 테이블과 매핑되는 객체입니다. 네이밍이 Test로 되어있어 부득이하게 Entity를 붙였는데, 실 개발시에는 Entity는 붙이지 않고 네이밍하여 도메인 별 비즈니스 로직도 함께 담아 작성할 예정입니다.
- 생성자 접근을 제한하여 빌더 사용을 강제했습니다.
- ID는 일단 기본값으로 지정했습니다. auto increment되는 컬럼으로 생성될 것인데, 필요하다면 추후 논의를 해봐야 할 것 같습니다.
- 매퍼 라이브러리(entity <-> dto) 사용을 고려해봤는데, 성능이 괜찮은 라이브러리는 테스트와 사용법 익히는데 오래걸리고, 현재 개발 규모에 별도의 라이브러리까지는 필요할 것 같지 않아 일단은 제외하고 수동으로(toDto) 만들어줬습니다.

**TestDTO**

- 마찬가지로 빌더 사용을 강제했고, 수동으로 매퍼를 작성했습니다.
- name 필드에 validator를 적용했습니다.
