### PR TITLE
Swagger setup

### DIFF
--- a/src/main/java/com/imd/yourvoice/common/CommonExceptionHandler.java
+++ b/src/main/java/com/imd/yourvoice/common/CommonExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.imd.yourvoice.common;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -10,34 +8,26 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @RestControllerAdvice
 public class CommonExceptionHandler {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseDTO<Map<String, Object>> methodArgumentNotValidExceptionHandler(ContentCachingRequestWrapper request) {
-        return ResponseDTO.<Map<String, Object>>builder()
-                .data(getRequestBodyAt(request))
                 .message("Validation Error")
+    public ResponseDTO<ExceptionResponse> methodArgumentNotValidExceptionHandler(ContentCachingRequestWrapper request) {
+        return ResponseDTO.<ExceptionResponse>builder()
+                .data(ExceptionResponse.of(request))
                 .isSuccess("fail")
                 .build();
     }
 
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseDTO<Map<String, Object>> httpMessageNotReadableExceptionHandler(ContentCachingRequestWrapper request) {
-        return ResponseDTO.<Map<String, Object>>builder()
-                .data(getRequestBodyAt(request))
                 .message("UnknownRequestProperties Error")
+    public ResponseDTO<ExceptionResponse> httpMessageNotReadableExceptionHandler(ContentCachingRequestWrapper request) {
+        return ResponseDTO.<ExceptionResponse>builder()
+                .data(ExceptionResponse.of(request))
                 .isSuccess("fail")
                 .build();
-    }
-
-    @SneakyThrows
-    private Map<String, Object> getRequestBodyAt(ContentCachingRequestWrapper request) {
-        return new ObjectMapper().readValue(request.getContentAsByteArray(), HashMap.class);
     }
 }

--- a/src/main/java/com/imd/yourvoice/common/CommonExceptionHandler.java
+++ b/src/main/java/com/imd/yourvoice/common/CommonExceptionHandler.java
@@ -13,20 +13,20 @@ public class CommonExceptionHandler {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-                .message("Validation Error")
     public ResponseDTO<ExceptionResponse> methodArgumentNotValidExceptionHandler(ContentCachingRequestWrapper request) {
         return ResponseDTO.<ExceptionResponse>builder()
                 .data(ExceptionResponse.of(request))
+                .message(HttpStatus.BAD_REQUEST.getReasonPhrase())
                 .isSuccess("fail")
                 .build();
     }
 
     @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     @ExceptionHandler(HttpMessageNotReadableException.class)
-                .message("UnknownRequestProperties Error")
     public ResponseDTO<ExceptionResponse> httpMessageNotReadableExceptionHandler(ContentCachingRequestWrapper request) {
         return ResponseDTO.<ExceptionResponse>builder()
                 .data(ExceptionResponse.of(request))
+                .message(HttpStatus.UNPROCESSABLE_ENTITY.getReasonPhrase())
                 .isSuccess("fail")
                 .build();
     }

--- a/src/main/java/com/imd/yourvoice/common/ExceptionResponse.java
+++ b/src/main/java/com/imd/yourvoice/common/ExceptionResponse.java
@@ -1,0 +1,21 @@
+package com.imd.yourvoice.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public class ExceptionResponse {
+    private Map<String, Object> requestBody;
+
+    @SneakyThrows
+    public static ExceptionResponse of(ContentCachingRequestWrapper requestWrapper) {
+        return new ExceptionResponse(new ObjectMapper().readValue(requestWrapper.getContentAsByteArray(), HashMap.class));
+    }
+}

--- a/src/main/java/com/imd/yourvoice/question/QuestionController.java
+++ b/src/main/java/com/imd/yourvoice/question/QuestionController.java
@@ -2,20 +2,24 @@ package com.imd.yourvoice.question;
 
 import com.imd.yourvoice.common.ResponseDTO;
 import com.imd.yourvoice.question.model.QuestionDTO;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
 @RestController
 public class QuestionController {
+
     @PostMapping("/question")
+    @ResponseStatus(HttpStatus.CREATED)
     public ResponseDTO<QuestionDTO> createQuestion(@RequestBody @Valid QuestionDTO.CreateRequest questionDTO) {
         return ResponseDTO.<QuestionDTO>builder()
                 .data(questionDTO.toEntity().toDTO())
                 .isSuccess("success")
-                .message("CREATE SUCCESSFUL")
+                .message(HttpStatus.CREATED.getReasonPhrase())
                 .build();
     }
 }

--- a/src/main/java/com/imd/yourvoice/question/model/Question.java
+++ b/src/main/java/com/imd/yourvoice/question/model/Question.java
@@ -33,6 +33,10 @@ public class Question {
     @OneToMany(mappedBy = "question")
     private List<QuestionLike> questionLikes;
 
+    public static Question of(UUID id) {
+        return new Question(id, null, "", "", null, null);
+    }
+
     public QuestionDTO toDTO() {
         return QuestionDTO.builder()
                 .id(id)

--- a/src/main/java/com/imd/yourvoice/question/model/QuestionDTO.java
+++ b/src/main/java/com/imd/yourvoice/question/model/QuestionDTO.java
@@ -3,6 +3,7 @@ package com.imd.yourvoice.question.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
@@ -19,6 +20,7 @@ import static com.imd.yourvoice.common.Const.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(name="Question")
 public class QuestionDTO {
     private UUID id;
 
@@ -49,6 +51,7 @@ public class QuestionDTO {
     @Builder
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Schema(name = "Question-CreateRequest")
     public static class CreateRequest {
         @NotEmpty
         @Size(max = 140)

--- a/src/main/java/com/imd/yourvoice/question/model/QuestionLike.java
+++ b/src/main/java/com/imd/yourvoice/question/model/QuestionLike.java
@@ -23,7 +23,7 @@ public class QuestionLike {
     public QuestionLikeDTO toDTO() {
         return QuestionLikeDTO.builder()
                 .id(id)
-                .question(question)
+                .questionId(question.getId())
                 .createDateTime(createDateTime)
                 .build();
     }

--- a/src/main/java/com/imd/yourvoice/question/model/QuestionLikeDTO.java
+++ b/src/main/java/com/imd/yourvoice/question/model/QuestionLikeDTO.java
@@ -3,6 +3,7 @@ package com.imd.yourvoice.question.model;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -10,13 +11,13 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class QuestionLikeDTO {
     private Long id;
-    private Question question;
+    private UUID questionId;
     private LocalDateTime createDateTime;
 
     public QuestionLike toEntity() {
         return QuestionLike.builder()
                 .id(id)
-                .question(question)
+                .question(Question.of(questionId))
                 .createDateTime(createDateTime)
                 .build();
     }

--- a/src/main/java/com/imd/yourvoice/sample/TestController.java
+++ b/src/main/java/com/imd/yourvoice/sample/TestController.java
@@ -1,5 +1,6 @@
 package com.imd.yourvoice.sample;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +11,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@Hidden
 public class TestController {
 
     private final TestService testService;

--- a/src/test/java/com/imd/yourvoice/question/QuestionControllerTest.java
+++ b/src/test/java/com/imd/yourvoice/question/QuestionControllerTest.java
@@ -1,6 +1,7 @@
 package com.imd.yourvoice.question;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.imd.yourvoice.common.ExceptionResponse;
 import com.imd.yourvoice.common.ResponseDTO;
 import com.imd.yourvoice.question.model.QuestionDTO;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,7 +40,7 @@ class QuestionControllerTest {
                 .content(objectMapper.writeValueAsString(input))
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(content().json(objectMapper.writeValueAsString(expected)));
     }
 
@@ -58,7 +60,7 @@ class QuestionControllerTest {
                                 .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
                                 .build(),
                         "isSuccess", "success",
-                        "message", "CREATE SUCCESSFUL"
+                        "message", HttpStatus.CREATED.getReasonPhrase()
                 )
         ));
     }
@@ -70,7 +72,7 @@ class QuestionControllerTest {
                 .content(input)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(content().json(objectMapper.writeValueAsString(expected)));
     }
 
@@ -86,7 +88,7 @@ class QuestionControllerTest {
                                 .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
                                 .build(),
                         "isSuccess", "success",
-                        "message", "CREATE SUCCESSFUL"
+                        "message", HttpStatus.CREATED.getReasonPhrase()
                 )
         ));
     }
@@ -98,7 +100,7 @@ class QuestionControllerTest {
                 .content(input)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnprocessableEntity())
                 .andExpect(content().json(objectMapper.writeValueAsString(expected)));
     }
 
@@ -107,13 +109,13 @@ class QuestionControllerTest {
         return Stream.of(Arguments.arguments(
                 "{\"contents\": \"test\", \"emoji\": \"test\",\"createDateTime\": \"2021-03-03 22:34:00\",\"test\" : \"test\"}",
                 ResponseDTO.builder()
-                        .data(Map.of(
+                        .data(new ExceptionResponse(Map.of(
                                 "contents", "test",
                                 "emoji", "test",
                                 "createDateTime", "2021-03-03 22:34:00",
                                 "test", "test"
-                        )).isSuccess("fail")
-                        .message("UnknownRequestProperties Error")
+                        ))).isSuccess("fail")
+                        .message(HttpStatus.UNPROCESSABLE_ENTITY.getReasonPhrase())
                         .build()
         ));
     }
@@ -139,13 +141,15 @@ class QuestionControllerTest {
                                 .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
                                 .build(),
                         ResponseDTO.builder()
-                                .data(QuestionDTO.CreateRequest.builder()
-                                        .contents("")
-                                        .emoji("test")
-                                        .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
-                                        .build())
+                                .data(Map.of(
+                                        "requestBody", QuestionDTO.CreateRequest.builder()
+                                                .contents("")
+                                                .emoji("test")
+                                                .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
+                                                .build()
+                                ))
                                 .isSuccess("fail")
-                                .message("Validation Error")
+                                .message(HttpStatus.BAD_REQUEST.getReasonPhrase())
                                 .build()
                 ), Arguments.arguments(
                         QuestionDTO.CreateRequest.builder()
@@ -154,13 +158,15 @@ class QuestionControllerTest {
                                 .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
                                 .build(),
                         ResponseDTO.builder()
-                                .data(QuestionDTO.CreateRequest.builder()
-                                        .contents("메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿")
-                                        .emoji("test")
-                                        .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
-                                        .build())
+                                .data(Map.of(
+                                        "requestBody", QuestionDTO.CreateRequest.builder()
+                                                .contents("메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿메세지메세지메세지굿")
+                                                .emoji("test")
+                                                .createDateTime(LocalDateTime.of(2021, 03, 03, 22, 34))
+                                                .build()
+                                ))
                                 .isSuccess("fail")
-                                .message("Validation Error")
+                                .message(HttpStatus.BAD_REQUEST.getReasonPhrase())
                                 .build()
                 )
         );


### PR DESCRIPTION
기본적인 세팅 완료 했습니다.
https://imd-your-voice.herokuapp.com/swagger-ui.html
30분동안 접속이 없으면 서버가 내려가서 느릴 수 있습니다.
너무 느리면 프로젝트 클론받아 터미널에서 `./gredlew bootrun` 입력해 실행할 수 있습니다. 직접 실행할 경우 jre11 이상 설치돼있어야 합니다.

이전 pr에서 https://github.com/Im-D/your-voice-back/pull/7#discussion_r591670563 이런 의견 있었는데, 스프링에서 HTTP status를 정의해둔 enum 클래스가 있어 활용했습니다.
> https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpStatus.html

isSuccess의 값으로 들어가는 success, fail은 
![image](https://user-images.githubusercontent.com/24666330/111318094-129f7580-86a8-11eb-8bc2-3cb68060b40d.png)
이런 식으로 정의된 enum을 활용해봐도 괜찮을 것 같은데 의견 부탁드립니다. 2xx, 4xx 같은 공통적인 에러 그룹을 나타내는 enum입니다. 마찬가지로 스프링에서 사용하는 enum 클래스입니다.

혹시나 이상한 부분이나, 추가되었으면 하는 부분 있으면 의견 부탁드립니다. 아마 저보다 여러분들이 더 많이 사용하게 될 것 같은데 필요한 기능 말씀해주시면 설정 가능한지 최대한 찾아보고 답변 드리겠습니다.

